### PR TITLE
Put the new state machine into stateMachineMap even it exists

### DIFF
--- a/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateMachineFactory.java
+++ b/cola-components/cola-component-statemachine/src/main/java/com/alibaba/cola/statemachine/StateMachineFactory.java
@@ -15,10 +15,6 @@ public class StateMachineFactory {
     static Map<String /* machineId */, StateMachine> stateMachineMap = new ConcurrentHashMap<>();
 
     public static <S, E, C> void register(StateMachine<S, E, C> stateMachine){
-        String machineId = stateMachine.getMachineId();
-        if(stateMachineMap.get(machineId) != null){
-            throw new StateMachineException("The state machine with id ["+machineId+"] is already built, no need to build again");
-        }
         stateMachineMap.put(stateMachine.getMachineId(), stateMachine);
     }
 


### PR DESCRIPTION
Put the new state machine into stateMachineMap even the state machine exists in stateMachineMap to avoid "The state machine with id ["+machineId+"] is already built, no need to build again" exception when you are using spring-boot-devtools.  If you are using spring-boot-devtools without configuration, the library "cola-statemachine" will be loaded in restartedClassLoader. when you modify code then click CTRL + F9. The new state machine will be put into stateMachineMap but it has existed then lead the error.